### PR TITLE
BUG: black and pre-commit only run on python>=3.6

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-black
-pre-commit
+black; python_version>='3.6'
+pre-commit; python_version>='3.6'


### PR DESCRIPTION
We change the requirements-dev.txt file so that these packages are only installed if the python version is high enough.