### PR TITLE
BUG: Sphinx requires explicit watchdog<1.0.0 on Py<3.6

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
 sphinx
 sphinx-autobuild
 sphinx_rtd_theme
+watchdog<1.0.0; python_version<'3.6'


### PR DESCRIPTION
Fixes sphinx install on Python 3.5.

Issue caused by insufficient specification down the dependency chain.