### PR TITLE
DEP: Need to specify exact black dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-black; python_version>='3.6'
+black==20.8b1; python_version>='3.6'
 pre-commit; python_version>='3.6'


### PR DESCRIPTION
Needs to be consistent with the version used in pre-commit.