### PR TITLE
MNT: Tidy up Sphinx entries

### DIFF
--- a/docs/genindex.rst
+++ b/docs/genindex.rst
@@ -1,0 +1,4 @@
+.. This file is a placeholder and will be replaced
+
+Index
+=====

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-Template documentation
-======================
+package_name documentation
+==========================
 
 .. toctree::
     :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,11 +7,5 @@ package_name documentation
 
     source/readme
     source/packages/modules
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+    py-modindex
+    genindex

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,11 +2,11 @@ Template documentation
 ======================
 
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+    :maxdepth: 2
+    :caption: Contents:
 
-   source/readme
-   source/packages/modules
+    source/readme
+    source/packages/modules
 
 
 Indices and tables

--- a/docs/py-modindex.rst
+++ b/docs/py-modindex.rst
@@ -1,0 +1,4 @@
+.. This file is a placeholder and will be replaced
+
+Module Index
+============

--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -1,1 +1,2 @@
 .. include:: ../../README.rst
+    :start-line: 2


### PR DESCRIPTION
- Change doc title from Template -> package_name, so it is easily changed with sed when creating a new repo.
- Move indices to table of contents, so they come up in the navigation tabs on the html pages
- Remove (non-functional) search page
- Remove the badges on the first line of README.rst from being included in the docs