### PR TITLE
CI:Docs: Add docs workflow to GHA

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: docs
 on: [push, pull_request]
 
 jobs:
-  docs:
+  docs-linux:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -19,3 +19,37 @@ jobs:
         docs-folder: "docs/"
         pre-build-command: "apt-get update -y && apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended"
         build-command: "make latexpdf"
+
+  docs-windows:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+
+    - name: System information
+      run: python .github/workflows/system_info.py
+
+    - name: Get pip cache dir
+      id: pip-cache
+      run: echo "::set-output name=dir::$(pip cache dir)"
+
+    - name: pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+        restore-keys: ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install .[docs]
+
+    - name: Build HTML docs
+      run: |
+        cd docs
+        make html
+        cd ..

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: docs
+
+on: [push, pull_request]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+
+    - name: Get pip cache dir
+      id: pip-cache
+      run: echo "::set-output name=dir::$(pip cache dir)"
+
+    - name: pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+        restore-keys: ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements-docs.txt ]; then pip install -r requirements-docs.txt; fi
+
+    - name: Build docs
+      run: |
+        make -C docs html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: ammaraskar/sphinx-action@master
+
+    - name: Build HTML docs
+      uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
+
+    - name: Build PDF docs
+      uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "docs/"
+        pre-build-command: "apt-get update -y && apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended"
+        build-command: "make latexpdf"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,25 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-
-    - name: Get pip cache dir
-      id: pip-cache
-      run: echo "::set-output name=dir::$(pip cache dir)"
-
-    - name: pip cache
-      uses: actions/cache@v2
+    - uses: ammaraskar/sphinx-action@master
       with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
-        restore-keys: ${{ runner.os }}-pip-
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ -f requirements-docs.txt ]; then pip install -r requirements-docs.txt; fi
-
-    - name: Build docs
-      run: |
-        make -C docs html
+        docs-folder: "docs/"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,7 @@ jobs:
         docs-folder: "docs/"
 
     - name: Build PDF docs
+      if: ${{ github.event_name == 'pull_request' }}
       uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
@@ -21,6 +22,8 @@ jobs:
         build-command: "make latexpdf"
 
   docs-windows:
+    if: ${{ github.event_name == 'pull_request' }}
+
     runs-on: windows-latest
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -308,8 +308,8 @@ Or you can build pdf documentation::
 On Windows, this becomes::
 
     cd docs
-    make.bat html
-    make.bat latexpdf
+    make html
+    make latexpdf
     cd ..
 
 - Your README.rst will become part of the generated documentation (via the file ``docs/source/readme.rst``).

--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,7 @@ When creating a new repository from this skeleton, these are the steps to follow
     - *No Documentation!* Delete these files and lines::
 
         rm -rf docs/
+        rm -f .github/workflows/docs.yml
         sed -i '70,74d' .github/workflows/test.yml
 
 #.  Delete the LICENSE file and replace it with a LICENSE file of your own choosing.
@@ -408,11 +409,14 @@ Three workflows are included:
 - lint
 - pre-commit
 - test
+- docs
 
 Both the lint and pre-commit workflows check for code style and formatting.
 If you are using the pre-commit hooks, the lint workflow is superfluous and can be deleted.
 
 The test workflow runs the unit tests.
+
+The docs workflow ensures the documentation builds correctly, and presents any errors and warnings very clearly.
 
 
 Other Continuous integration

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+-r ../requirements.txt
+-r ../requirements-docs.txt


### PR DESCRIPTION
Add a docs workflow, which uses sphinx-action. This writes any errors and warnings as annotations, which are easy to read.

We also make sure the docs build as a PDF, and build as HTML on Windows, but run these only on PRs.