### PR TITLE
CI:GHA: Test on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -216,11 +216,8 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  - "%CMD_IN_ENV% python -m pip install ."
+  - "%CMD_IN_ENV% python -m pip install .[test]"
   - IF "%BUILD_DOCS%"=="true" ( %CMD_IN_ENV% python -m pip install .[docs] )
-  # Also install any developmental requirements, if present.
-  - IF EXIST requirements-dev.txt %CMD_IN_ENV% pip install -r requirements-dev.txt
-  - IF EXIST requirements-test.txt %CMD_IN_ENV% pip install -r requirements-test.txt
 
 build_script:
   # Build the compiled extension

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
         include:
           - os: macos-latest
             python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.9"
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
@@ -71,4 +73,6 @@ jobs:
     - name: Build HTML docs
       run: |
         python -m pip install .[docs]
-        make -C docs html
+        cd docs
+        make html
+        cd ..

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
+        python -m pip install .[test]
 
     - name: Sanity check with flake8
       run: |
@@ -69,7 +68,7 @@ jobs:
         env_vars: OS,PYTHON
         name: Python ${{ matrix.python-version }} on ${{ runner.os }}
 
-    - name: Build docs
+    - name: Build HTML docs
       run: |
-        if [ -f requirements-docs.txt ]; then pip install -r requirements-docs.txt; fi
+        python -m pip install .[docs]
         make -C docs html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ When creating a new repository from this skeleton, these are the steps to follow
 
         rm -rf docs/
         rm -f .github/workflows/docs.yml
-        head -n -5 .github/workflows/test.yml > .github/workflows/test.yml
+        head -n -7 .github/workflows/test.yml > .github/workflows/test.yml
         sed -i 's/BUILD_DOCS: "true"/BUILD_DOCS: "false"/' .appveyor.yml
         sed -i 's/BUILD_DOCS="true"/BUILD_DOCS="false"/' .travis.yml
 


### PR DESCRIPTION
- Add a build to test latest Python on Windows.
- Change GHA and Appveyor CI to install test and docs with package extras instead of specifying the requirements.txt files directly. This ensures we test setup.py is set up correctly so the extras install, and is flexible in case the txt files are moved.