### PR TITLE
MNT:TST: Drop Python 2.6 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -400,8 +400,6 @@ The file ``package_name/tests/base_test.py`` provides a class for unit testing w
 
 If you aren't using doing numeric tests, you can delete this from the ``package_name/tests/base_test.py`` file.
 
-There is also support for ``unittest`` on Python 2.6 (via ``unittest2``), in case you still need to support it.
-
 
 GitHub Actions Workflows
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/package_name/tests/base_test.py
+++ b/package_name/tests/base_test.py
@@ -7,6 +7,7 @@ Includes the numpy testing functions as methods.
 import contextlib
 import os.path
 import sys
+import unittest
 from inspect import getsourcefile
 
 import numpy as np
@@ -24,12 +25,6 @@ from numpy.testing import (
     assert_string_equal,
     assert_warns,
 )
-
-# For Python < 2.7, unittest2 is a backport of unittest
-if sys.version_info[:2] <= (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
 
 
 class BaseTestCase(unittest.TestCase):


### PR DESCRIPTION
Remove Python 2.6 support from unit testing.