### PR TITLE
ENH: Support elastic search on readthedocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,8 +111,13 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
-    "sphinx_search.extension",
 ]
+
+# Some extension features only available on later Python versions
+if sys.version_info >= (3, 6):
+    # Enables search as you type with Elasticsearch on readthedocs.com
+    # but only available on Python 3.6 and above.
+    extensions.append("sphinx_search.extension")
 
 # Napoleon settings
 napoleon_google_docstring = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,6 +111,7 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
+    "sphinx_search.extension",
 ]
 
 # Napoleon settings

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-readthedocs-sphinx-search
+readthedocs-sphinx-search; python_version>='3.6'
 sphinx
 sphinx-autobuild
 sphinx_rtd_theme

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
+readthedocs-sphinx-search
 sphinx
 sphinx-autobuild
 sphinx_rtd_theme


### PR DESCRIPTION
Enables "search as you type" on readthedocs https://docs.readthedocs.io/en/stable/guides/searching-with-readthedocs.html#enable-search-as-you-type-in-your-documentation