### PR TITLE
CI: Improve GHA

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,9 +1,15 @@
+# Docs workflow
+#
+# Ensures that the docs can be built with sphinx.
+# - On every push and PR, checks the HTML documentation builds on linux.
+# - On every PR and tag, checks the documentation builds as a PDF on linux.
+
 name: docs
 
 on: [push, pull_request]
 
 jobs:
-  docs-linux:
+  html:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -13,10 +19,24 @@ jobs:
       with:
         docs-folder: "docs/"
 
+  pdf:
+    if: |
+      github.event_name == 'pull_request' ||
+      startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
     - name: Build PDF docs
-      if: ${{ github.event_name == 'pull_request' }}
       uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
         pre-build-command: "apt-get update -y && apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended"
         build-command: "make latexpdf"
+
+    - uses: actions/upload-artifact@v2
+      if: startsWith(github.ref, 'refs/tags')
+      with:
+        name: Documentation
+        path: docs/_build/latex/*.pdf
+        retention-days: 7

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,7 +9,7 @@ name: docs
 on: [push, pull_request]
 
 jobs:
-  html:
+  docs-html:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -19,7 +19,7 @@ jobs:
       with:
         docs-folder: "docs/"
 
-  pdf:
+  docs-pdf:
     if: |
       github.event_name == 'pull_request' ||
       startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,39 +20,3 @@ jobs:
         docs-folder: "docs/"
         pre-build-command: "apt-get update -y && apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended"
         build-command: "make latexpdf"
-
-  docs-windows:
-    if: ${{ github.event_name == 'pull_request' }}
-
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Python
-      uses: actions/setup-python@v2
-
-    - name: System information
-      run: python .github/workflows/system_info.py
-
-    - name: Get pip cache dir
-      id: pip-cache
-      run: echo "::set-output name=dir::$(pip cache dir)"
-
-    - name: pip cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
-        restore-keys: ${{ runner.os }}-pip-
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install .[docs]
-
-    - name: Build HTML docs
-      run: |
-        cd docs
-        make html
-        cd ..

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,3 +1,11 @@
+# Lint workflow
+#
+# Ensures the code is formatted correctly.
+# - On every push and PR, checks the code style conforms to the black format.
+# - On every push and PR, checks the code is both PEP8 compliant and passes the
+#   pyflakes error detector (both tests done with flake8). We use some flake8
+#   plugins to check some extra things, such as docstring formatting.
+
 name: lint
 
 on: [push, pull_request]

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,3 +1,8 @@
+# pre-commit workflow
+#
+# Ensures the codebase passes the pre-commit stack, to catch in case developers
+# don't have pre-commit set up locally.
+
 name: pre-commit
 
 on: [push, pull_request]

--- a/.github/workflows/test-release-candidate.yaml
+++ b/.github/workflows/test-release-candidate.yaml
@@ -1,0 +1,115 @@
+# Tests for releases and release candidates
+#
+# Runs on every tag creation, and all pushes and PRs to release branches
+# named "v1.2.x", etc.
+#
+# This workflow is more extensive than the regular test workflow.
+# - Tests are executed on more Python versions
+# - Tests are run on more operating systems
+# - N.B. There is no pip cache here to ensure runs are always against the
+#   very latest versions of dependencies, even if this workflow ran recently.
+#
+# In addition, the package is built as a wheel on each OS/Python job, and these
+# are stored as artifacts to use for your distribution process.
+
+name: release candidate tests
+
+on:
+  push:
+    branches:
+      # Release branches.
+      # Examples: "v1", "v3.0", "v1.2.x", "1.5.0", "1.2rc0"
+      # Expected usage is (for example) a branch named "v1.2.x" which contains
+      # the latest release in the 1.2 series.
+      - 'v[0-9]+'
+      - 'v?[0-9]+.[0-9x]+'
+      - 'v?[0-9]+.[0-9]+.[0-9x]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+.[0-9x]+'
+      - 'v?[0-9]+.[0-9x]+rc[0-9]*'
+    tags:
+      # Run whenever any tag is created
+      - '**'
+  pull_request:
+    branches:
+      # Release branches
+      - 'v[0-9]+'
+      - 'v?[0-9]+.[0-9x]+'
+      - 'v?[0-9]+.[0-9]+.[0-9x]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+.[0-9x]+'
+      - 'v?[0-9]+.[0-9x]+rc[0-9]*'
+  release:
+    # Run on a new release
+    types: [created, edited, published]
+
+jobs:
+  test-build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9"]
+        include:
+          - os: macos-latest
+            python-version: "2.7"
+          - os: macos-latest
+            python-version: "3.9"
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: System information
+      run: python .github/workflows/system_info.py
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8
+        python -m pip install .[test]
+
+    - name: Sanity check with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings
+        python -m flake8 . --count --exit-zero --statistics
+
+    - name: Debug environment
+      run: python -m pip freeze
+
+    - name: Test with pytest
+      run: |
+        python -m pytest --cov=package_name --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        flags: unittests
+        env_vars: OS,PYTHON
+        name: Python ${{ matrix.python-version }} on ${{ runner.os }}
+
+    - name: Build wheels
+      run: |
+        python -m pip install --upgrade setuptools wheel twine
+        python setup.py sdist bdist_wheel
+
+    - name: Store wheel artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheel-${{ matrix.os }}-${{ matrix.python-version }}
+        path: dist/*
+        retention-days: 7
+
+    - name: Build HTML docs
+      run: |
+        python -m pip install .[docs]
+        cd docs
+        make html
+        cd ..

--- a/.github/workflows/test-release-candidate.yaml
+++ b/.github/workflows/test-release-candidate.yaml
@@ -10,7 +10,8 @@
 #   very latest versions of dependencies, even if this workflow ran recently.
 #
 # In addition, the package is built as a wheel on each OS/Python job, and these
-# are stored as artifacts to use for your distribution process.
+# are stored as artifacts to use for your distribution process. There is an
+# extra job (disabled by default) which can be enabled to push to Test PyPI.
 
 name: release candidate tests
 
@@ -113,3 +114,34 @@ jobs:
         cd docs
         make html
         cd ..
+
+  publish:
+    # Disabled by default
+    if: |
+      false &&
+      startsWith(github.ref, 'refs/tags/')
+    needs: test-build
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Download wheel artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: wheel-*
+        path: dist/
+
+    - name: Store aggregated wheel artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheels
+        path: dist/*
+        retention-days: 7
+
+    - name: Publish package to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,6 +59,9 @@ jobs:
         # exit-zero treats all errors as warnings
         python -m flake8 . --count --exit-zero --statistics
 
+    - name: Debug environment
+      run: python -m pip freeze
+
     - name: Test with pytest
       run: |
         python -m pytest --cov=package_name --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,21 @@
+# Regular tests
+#
+# Use this to ensure your tests are passing on every push and PR (skipped on
+# pushes which only affect documentation).
+# There is also a cron job set to run weekly on the default branch, to check
+# against dependency chain rot.
+#
+# You should make sure you run jobs on at least the *oldest* and the *newest*
+# versions of python that your codebase is intended to support.
+
 name: tests
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - '**.rst'
+      - '**.md'
   pull_request:
   schedule:
     - cron:  "0 0 * * 1"
@@ -9,15 +23,12 @@ on:
 
 jobs:
   test:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["2.7", "3.5", "3.9"]
         include:
-          - os: macos-latest
-            python-version: "3.9"
           - os: windows-latest
             python-version: "3.9"
     env:

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,8 @@ When creating a new repository from this skeleton, these are the steps to follow
 
     - *No Python 2.7 support!* Delete these items from the unit testing CI::
 
-        sed -i 's/"2\.7", //' .github/workflows/test.yaml
+        sed -i 's/"2\.7", //' .github/workflows/test*.yaml
+        sed -i '"2\.7"/"3\.5"/' .github/workflows/test*.yaml
         sed -i '/- "2\.7"/d' .travis.yml
         sed -i '31,40d' .appveyor.yml
         sed -i '16,24d' .appveyor.yml
@@ -77,7 +78,7 @@ When creating a new repository from this skeleton, these are the steps to follow
 
         rm -rf .ci/
         rm -rf package_name/tests/
-        rm -f .github/workflows/test.yaml
+        rm -f .github/workflows/test*.yaml
         rm -f .appveyor.yml
         rm -f .coveragerc
         rm -f .travis.yml
@@ -97,6 +98,7 @@ When creating a new repository from this skeleton, these are the steps to follow
         rm -rf docs/
         rm -f .github/workflows/docs.yaml
         head -n -7 .github/workflows/test.yaml > .github/workflows/test.yaml
+        head -n -7 .github/workflows/test-release-candidate.yaml > .github/workflows/test-release-candidate.yaml
         sed -i 's/BUILD_DOCS: "true"/BUILD_DOCS: "false"/' .appveyor.yml
         sed -i 's/BUILD_DOCS="true"/BUILD_DOCS="false"/' .travis.yml
 
@@ -138,7 +140,7 @@ When creating a new repository from this skeleton, these are the steps to follow
         PACKAGE_NAME=your_actual_package_name
         sed -i "s/package_name/$PACKAGE_NAME/" setup.py \
             docs/conf.py docs/index.rst \
-            .github/workflows/test.yaml .travis.yml .appveyor.yml
+            .github/workflows/test*.yaml .travis.yml .appveyor.yml
 
     Which will make changes in the following places.
 
@@ -154,7 +156,7 @@ When creating a new repository from this skeleton, these are the steps to follow
 
         package_name documentation
 
-    - In ``.github/workflows/test.yaml``, `L78 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/test.yaml#L78>`_::
+    - In ``.github/workflows/test.yaml``, `L78 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/test.yaml#L78>`_, and ``.github/workflows/test-release-candidate.yaml``, `L89 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/test-release-candidate.yaml#L89>`_::
 
         python -m pytest --cov=package_name --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml
 
@@ -404,19 +406,24 @@ If you aren't using doing numeric tests, you can delete this from the ``package_
 GitHub Actions Workflows
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Four workflows are included:
+Five workflows are included:
 
+- docs
 - lint
 - pre-commit
 - test
-- docs
+- release candidate tests
+
+The docs workflow ensures the documentation builds correctly, and presents any errors and warnings nicely as annotations.
 
 Both the lint and pre-commit workflows check for code style and formatting.
 If you are using the pre-commit hooks, the lint workflow is superfluous and can be deleted.
 
 The test workflow runs the unit tests.
 
-The docs workflow ensures the documentation builds correctly, and presents any errors and warnings very clearly.
+The release candidate tests workflow runs the unit tests on more Python versions and operating systems than the regular test workflow.
+This runs on all tags, plus pushes and PRs to branches named like "v1.2.x", etc.
+Wheels are built for all the tested systems, and stored as artifacts for your convenience when shipping a new distribution.
 
 
 Other Continuous integration

--- a/README.rst
+++ b/README.rst
@@ -233,7 +233,7 @@ If you want to upgrade to a newer version of black, you must change the version 
 
 - requirements-dev.txt, `L1 <https://github.com/scottclowe/python-template-repo/blob/master/requirements-dev.txt#L1>`_
 - .pre-commit-config.yaml, `L14 <https://github.com/scottclowe/python-template-repo/blob/master/.pre-commit-config.yaml#L14>`_ and `L24 <https://github.com/scottclowe/python-template-repo/blob/master/.pre-commit-config.yaml#L24>`_
-- .github/workflows/lint.yaml, `L11 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/lint.yaml#L11>`_
+- .github/workflows/lint.yaml, `L19 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/lint.yaml#L19>`_
 
 .. _black: https://github.com/psf/black
 

--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ When creating a new repository from this skeleton, these are the steps to follow
 
         package_name documentation
 
-    - In ``.github/workflows/test.yaml``, `L65 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/test.yaml#L65>`_::
+    - In ``.github/workflows/test.yaml``, `L78 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/test.yaml#L78>`_::
 
         python -m pytest --cov=package_name --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml
 

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,6 @@ When creating a new repository from this skeleton, these are the steps to follow
         rm -rf docs/
         rm -f .github/workflows/docs.yaml
         head -n -7 .github/workflows/test.yaml > .github/workflows/test.yaml
-        head -n -7 .github/workflows/test-release-candidate.yaml > .github/workflows/test-release-candidate.yaml
         sed -i 's/BUILD_DOCS: "true"/BUILD_DOCS: "false"/' .appveyor.yml
         sed -i 's/BUILD_DOCS="true"/BUILD_DOCS="false"/' .travis.yml
 
@@ -156,7 +155,7 @@ When creating a new repository from this skeleton, these are the steps to follow
 
         package_name documentation
 
-    - In ``.github/workflows/test.yaml``, `L78 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/test.yaml#L78>`_, and ``.github/workflows/test-release-candidate.yaml``, `L89 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/test-release-candidate.yaml#L89>`_::
+    - In ``.github/workflows/test.yaml``, `L78 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/test.yaml#L78>`_, and ``.github/workflows/test-release-candidate.yaml``, `L90 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/test-release-candidate.yaml#L90>`_::
 
         python -m pytest --cov=package_name --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml
 
@@ -424,6 +423,17 @@ The test workflow runs the unit tests.
 The release candidate tests workflow runs the unit tests on more Python versions and operating systems than the regular test workflow.
 This runs on all tags, plus pushes and PRs to branches named like "v1.2.x", etc.
 Wheels are built for all the tested systems, and stored as artifacts for your convenience when shipping a new distribution.
+
+If you enable the ``publish`` job on the release candidate tests workflow, you can push built release candidates to the `Test PyPI <testpypi_>`_ server.
+For this to work, you'll also need to add your Test `PyPI API token <pypi-api-token_>`_ to your `GitHub secrets <github-secrets_>`_.
+Checkout the `pypa/gh-action-pypi-publish <pypi-publish_>`_ GitHub action, and `PyPI's guide on distributing from CI <ci-packaging_>`_ for more information on this.
+With minimal tweaks, this job can be changed to push to PyPI for real, but be careful with this since releases on PyPI can not easily be yanked.
+
+.. _ci-packaging: https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+.. _github-secrets: https://docs.github.com/en/actions/reference/encrypted-secrets
+.. _pypi-api-token: https://pypi.org/help/#apitoken
+.. _pypi-publish: https://github.com/pypa/gh-action-pypi-publish
+.. _testpypi: https://test.pypi.org/
 
 
 Other Continuous integration

--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ When creating a new repository from this skeleton, these are the steps to follow
 
         package_name documentation
 
-    - In ``.github/workflows/test.yaml``, `L62 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/test.yaml#L62>`_::
+    - In ``.github/workflows/test.yaml``, `L65 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/test.yaml#L65>`_::
 
         python -m pytest --cov=package_name --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml
 


### PR DESCRIPTION
- Reduce matrix for regular tests
- Add extensive release candidate tests workflow, which tests a larger matrix and stores artifacts
- Add disabled job which publishes wheels on Test PyPI
- Remove redundant docs-windows job (covered by test workflow)
- Save pdf documentation output for tags