### PR TITLE
MNT: Move README included in docs to index page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,11 +1,13 @@
 package_name documentation
 ==========================
 
+.. include:: ../README.rst
+    :start-line: 2
+
 .. toctree::
     :maxdepth: 2
     :caption: Contents:
 
-    source/readme
     source/packages/modules
     py-modindex
     genindex

--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -1,2 +1,0 @@
-.. include:: ../../README.rst
-    :start-line: 2


### PR DESCRIPTION
Instead of having it on its own page.