### PR TITLE
BUG: Fix double heading

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,3 @@
-package_name documentation
-==========================
-
 .. include:: ../README.rst
     :start-line: 2
 


### PR DESCRIPTION
Don't need to add our own heading to index.rst when README.rst has
one.