### PR TITLE
BUG: Drop unittest2, since Python 2.6 support dropped

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
 pytest
 pytest-cov
 pytest-flake8
-unittest2; python_version<'2.7'


### PR DESCRIPTION
Should have been included in #19.