### PR TITLE
BUG: Only extend flake8 ignore list

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,13 +1,11 @@
 [flake8]
 max-line-length = 88
-# E203: whitespace before ':'. Sometimes violated by black.
+# E203: whitespace before ":". Sometimes violated by black.
 # E402: Module level import not at top of file. Violated by lazy imports.
 # F401: Module imported but unused.
-# W503: Line break occurred before a binary operator. Recommended style changed to W504.
-# D200: One-line docstring should fit on one line with quotes.
-ignore = E203,E402,F401,W503,D200
 # D100-D107: Missing docstrings
-extend-ignore = D100,D101,D102,D103,D104,D105,D106,D107
+# D200: One-line docstring should fit on one line with quotes.
+extend-ignore = E203,E402,F401,D100,D101,D102,D103,D104,D105,D106,D107,D200
 docstring-convention = numpy
 # Ignore missing docstrings within unit testing functions.
 per-file-ignores = **/tests/:D100,D101,D102,D103,D104,D105,D106,D107


### PR DESCRIPTION
If the "ignore" field is set, this overwrites the default ignore list (which contains W503, amongst others).