### PR TITLE
BUG:DOC: Add main requirements.txt to docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
+-r ../requirements.txt
 -r ../requirements-docs.txt


### PR DESCRIPTION
This is needed because we build the api documentation on the fly with apidoc, and that means we need to be able to import all of the modules in the package to build the documentation.