### PR TITLE
Drop Python 2.7 and Python 3.5 support

### DIFF
--- a/.github/workflows/test-release-candidate.yaml
+++ b/.github/workflows/test-release-candidate.yaml
@@ -48,10 +48,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
         include:
           - os: macos-latest
-            python-version: "2.7"
+            python-version: "3.6"
           - os: macos-latest
             python-version: "3.9"
     env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["2.7", "3.5", "3.9"]
+        python-version: ["3.6", "3.9"]
         include:
           - os: windows-latest
             python-version: "3.9"

--- a/README.rst
+++ b/README.rst
@@ -64,12 +64,6 @@ When creating a new repository from this skeleton, these are the steps to follow
         rm -f .github/workflows/pre-commit.yaml
         sed -i '/^pre-commit/d' requirements-dev.txt
 
-    - *No Python 2.7 support!*
-      Run the following commands to delete references to Python 2.7 from the unit testing CI::
-
-        sed -i 's/"2\.7", //' .github/workflows/test*.yaml
-        sed -i '"2\.7"/"3\.5"/' .github/workflows/test*.yaml
-
     - *No GitHub Actions!*
       Delete the .github directory::
 

--- a/package_name/tests/base_test.py
+++ b/package_name/tests/base_test.py
@@ -4,7 +4,6 @@ Provides a base test class for other test classes to inherit from.
 Includes the numpy testing functions as methods.
 """
 
-import contextlib
 import os.path
 import sys
 import unittest
@@ -86,15 +85,6 @@ class BaseTestCase(unittest.TestCase):
         # Add a test to automatically use when comparing objects of
         # type numpy ndarray. This will be used for self.assertEqual().
         self.addTypeEqualityFunc(np.ndarray, self.assert_allclose)
-
-    @contextlib.contextmanager
-    def subTest(self, *args, **kwargs):
-        # For backwards compatability with Python < 3.4
-        # Gracefully degrades into no-op.
-        if hasattr(super(BaseTestCase, self), "subTest"):
-            yield super(BaseTestCase, self).subTest(*args, **kwargs)
-        else:
-            yield None
 
     @pytest.fixture(autouse=True)
     def capsys(self, capsys):

--- a/package_name/tests/base_test.py
+++ b/package_name/tests/base_test.py
@@ -79,13 +79,10 @@ class BaseTestCase(unittest.TestCase):
     # test resources - files which are needed to run tests.
     test_directory = TEST_DIRECTORY
 
-    def __init__(self, *args, **kw):
+    def __init__(self, *args, **kwargs):
         """Instance initialisation."""
-        # First to the __init__ associated with parent class
-        # NB: The new method is like so, but this only works on Python3
-        # super(self).__init__(*args, **kw)
-        # So we have to do this for Python2 to be supported
-        super(BaseTestCase, self).__init__(*args, **kw)
+        # First do the __init__ associated with parent class
+        super().__init__(*args, **kwargs)
         # Add a test to automatically use when comparing objects of
         # type numpy ndarray. This will be used for self.assertEqual().
         self.addTypeEqualityFunc(np.ndarray, self.assert_allclose)

--- a/package_name/tests/base_test.py
+++ b/package_name/tests/base_test.py
@@ -51,9 +51,7 @@ def assert_starts_with(actual, desired):
         print("ACTUAL: {}".format(actual))
         raise
     try:
-        # Can't use numpy.testing.assert_string_equal on Python 2.7 due to
-        # string type errors
-        return assert_equal(str(actual)[: len(desired)], desired)
+        return assert_string_equal(str(actual)[: len(desired)], desired)
     except BaseException as err:
         msg = "ACTUAL: {}".format(actual)
         if isinstance(getattr(err, "args", None), str):

--- a/package_name/tests/test_module.py
+++ b/package_name/tests/test_module.py
@@ -31,9 +31,7 @@ class TestVerbose(BaseTestCase):
         capture_pre = self.capsys.readouterr()  # Clear stdout
         print(message)  # Execute method (verbose)
         capture_post = self.recapsys(capture_pre)  # Capture and then re-output
-        # Can't use numpy.testing.assert_string_equal on Python 2.7 due to
-        # string type errors
-        self.assert_equal(capture_post.out.strip(), message)
+        self.assert_string_equal(capture_post.out.strip(), message)
 
     def test_shakespeare(self):
         # Clear stdout (in this case, an empty capture)


### PR DESCRIPTION
These have already passed their end of life dates last year.

Python 2.7 EOL: 01 Jan 2020
Python 3.5 EOL: 13 Sep 2020