### PR TITLE
CI: Do editable install to ensure correct coverage tracking

### DIFF
--- a/.github/workflows/test-release-candidate.yaml
+++ b/.github/workflows/test-release-candidate.yaml
@@ -73,7 +73,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8
-        python -m pip install .[test]
+        python -m pip install --editable .[test]
 
     - name: Sanity check with flake8
       run: |
@@ -109,7 +109,7 @@ jobs:
 
     - name: Build HTML docs
       run: |
-        python -m pip install .[docs]
+        python -m pip install --editable .[docs]
         cd docs
         make html
         cd ..

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,7 +61,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8
-        python -m pip install .[test]
+        python -m pip install --editable .[test]
 
     - name: Sanity check with flake8
       run: |
@@ -86,7 +86,7 @@ jobs:
 
     - name: Build HTML docs
       run: |
-        python -m pip install .[docs]
+        python -m pip install --editable .[docs]
         cd docs
         make html
         cd ..


### PR DESCRIPTION
This makes sure the file names aren't discovered at the site-packages directory instead of the local directory.