### PR TITLE
REL: Add minimal pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include CHANGELOG.rst
 include LICEN[CS]E*
+include pyproject.toml
 include README.rst
 include requirements*.txt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
We add a minimal pyproject.toml that directs `python -m build` to use our setup.py script.

Closes #48.