### PR TITLE
CI:GHA: Always run tests, don't skip based on content

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,10 +12,6 @@ name: tests
 
 on:
   push:
-    paths-ignore:
-      - 'docs/**'
-      - '**.rst'
-      - '**.md'
   pull_request:
   schedule:
     - cron:  "0 0 * * 1"


### PR DESCRIPTION
This is because we always need to run on pushes to the master branch. We would like to skip running the tests on pushes to other branches which don't affect the codebase, but it is not clear to me if this is actually possible using just the github workflow event triggers.