### PR TITLE
DEV: Add utf-8 pragma to top of python files

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -14,4 +14,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
+    - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/system_info.py
+++ b/.github/workflows/system_info.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Print out some handy system info.
 """

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,7 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
         exclude: ^LICENSE|\.(html|csv|txt|svg|py)$
+      - id: fix-encoding-pragma
       - id: pretty-format-json
         args: ["--autofix", "--no-ensure-ascii", "--no-sort-keys"]
       - id: requirements-txt-fixer

--- a/package_name/__init__.py
+++ b/package_name/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from . import __meta__
 
 __version__ = __meta__.version

--- a/package_name/__meta__.py
+++ b/package_name/__meta__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # `name` is the name of the package as used for `pip install package`
 name = "package-name"
 # `path` is the name of the package for `import package`

--- a/package_name/module.py
+++ b/package_name/module.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Module provides a simple cubic_rectification function.
 """

--- a/package_name/tests/base_test.py
+++ b/package_name/tests/base_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Provides a base test class for other test classes to inherit from.
 

--- a/package_name/tests/test_module.py
+++ b/package_name/tests/test_module.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Tests for module in package_name.
 """

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import glob
 import os


### PR DESCRIPTION
Add utf-8 pragma to the start of all python files. This is needed for Python 2 to support unicode characters in source code. We also add a pre-commit hook to ensure all files have this.