### PR TITLE
DEV: Improvements to nbqa pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,12 @@ repos:
       - id: nbqa-isort
         args: ["--nbqa-mutate", "--profile=black"]
       - id: nbqa-black
-        args: [--nbqa-mutate]
+        args:
+            - "--nbqa-mutate"
+            - "--target-version=py36"
+            - "--target-version=py37"
+            - "--target-version=py38"
+            - "--target-version=py39"
         additional_dependencies: [black==21.7b0]
 
   - repo: https://github.com/pre-commit/pygrep-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,7 @@ repos:
             - "--target-version=py38"
             - "--target-version=py39"
         additional_dependencies: [black==21.7b0]
+      - id: nbqa-flake8
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,11 +35,11 @@ repos:
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 0.13.1
     hooks:
+      - id: nbqa-isort
+        args: ["--nbqa-mutate", "--profile=black"]
       - id: nbqa-black
         args: [--nbqa-mutate]
         additional_dependencies: [black==21.7b0]
-      - id: nbqa-isort
-        args: ["--nbqa-mutate", "--profile=black"]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0


### PR DESCRIPTION
- Specify which versions black should target when running on notebooks (python >= 3.6)
- Check notebooks with flake8.