### PR TITLE
DEV: Improvements to nbqa pre-commit (python 2.7)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,14 @@ repos:
       - id: nbqa-isort
         args: ["--nbqa-mutate", "--profile=black"]
       - id: nbqa-black
-        args: [--nbqa-mutate]
+        args:
+            - "--nbqa-mutate"
+            - "--target-version=py27"
+            - "--target-version=py35"
+            - "--target-version=py36"
+            - "--target-version=py37"
+            - "--target-version=py38"
+            - "--target-version=py39"
         additional_dependencies: [black==21.7b0]
 
   - repo: https://github.com/pre-commit/pygrep-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     rev: v1.10.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==21.6b0]
+        additional_dependencies: [black==21.7b0]
 
   - repo: https://github.com/kynan/nbstripout
     rev: 0.5.0
@@ -39,7 +39,7 @@ repos:
     hooks:
        - id: nbqa-black
          args: [--nbqa-mutate]
-         additional_dependencies: [black==21.6b0]
+         additional_dependencies: [black==21.7b0]
        - id: nbqa-isort
          args: ["--nbqa-mutate", "--profile=black"]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
             - "--target-version=py38"
             - "--target-version=py39"
         additional_dependencies: [black==21.7b0]
+      - id: nbqa-flake8
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,11 +37,11 @@ repos:
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 0.13.1
     hooks:
+      - id: nbqa-isort
+        args: ["--nbqa-mutate", "--profile=black"]
       - id: nbqa-black
         args: [--nbqa-mutate]
         additional_dependencies: [black==21.7b0]
-      - id: nbqa-isort
-        args: ["--nbqa-mutate", "--profile=black"]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,11 +37,11 @@ repos:
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 0.13.1
     hooks:
-       - id: nbqa-black
-         args: [--nbqa-mutate]
-         additional_dependencies: [black==21.7b0]
-       - id: nbqa-isort
-         args: ["--nbqa-mutate", "--profile=black"]
+      - id: nbqa-black
+        args: [--nbqa-mutate]
+        additional_dependencies: [black==21.7b0]
+      - id: nbqa-isort
+        args: ["--nbqa-mutate", "--profile=black"]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-black==21.6b0; python_version>='3.6'
+black==21.7b0; python_version>='3.6'
 identify>=1.4.20
 pre-commit


### PR DESCRIPTION
- Upgrade black to 21.7b0.
- Specify which versions black should target when running on notebooks (python 2.7, >=3.5)
- Check notebooks with flake8.