### PR TITLE
DEV: Drop --nbqa-mutate, deprecated in nbQA v1.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,10 +36,9 @@ repos:
     rev: 1.1.0
     hooks:
       - id: nbqa-isort
-        args: ["--nbqa-mutate", "--profile=black"]
+        args: ["--profile=black"]
       - id: nbqa-black
         args:
-            - "--nbqa-mutate"
             - "--target-version=py36"
             - "--target-version=py37"
             - "--target-version=py38"


### PR DESCRIPTION
This is now the default behaviour, so it is no longer necessary to supply the `--nbqa-mutate` argument. Since it was deprecated, we need to remove the old argument.