### PR TITLE
CI+DEV+BUG: Fix bugs preventing CI from running

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,12 +21,13 @@ repos:
             - "--target-version=py39"
             - "--target-version=py310"
         types: [python]
+        additional_dependencies: ["click<=8.0.4"]
 
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.12.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==22.1.0]
+        additional_dependencies: ["black==22.1.0", "click<=8.0.4"]
 
   - repo: https://github.com/kynan/nbstripout
     rev: 0.5.0
@@ -45,7 +46,7 @@ repos:
             - "--target-version=py38"
             - "--target-version=py39"
             - "--target-version=py310"
-        additional_dependencies: [black==22.1.0]
+        additional_dependencies: ["black==22.1.0", "click<=8.0.4"]
       - id: nbqa-flake8
 
   - repo: https://github.com/pre-commit/pygrep-hooks

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 black==22.1.0; python_version>='3.6'
+click<=8.0.4
 identify>=1.4.20
 pre-commit

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,7 +1,7 @@
 myst-parser
 pypandoc>=1.6.3
 readthedocs-sphinx-search; python_version>='3.6'
-sphinx
+sphinx>=3.5.4
 sphinx-autobuild
 sphinx_book_theme
 watchdog<1.0.0; python_version<'3.6'


### PR DESCRIPTION
1. A change in the back-end code of the package click (v8.0.5) broke black. To fix this, we need to specify click<=8.0.4, or upgrade to black>=22.3.0. See https://github.com/psf/black/issues/2964.

2. An unknown change in the GHA CI has caused the documentation build to start failing. It installs sphinx=2.4.4 and raises incompatibility warnings:
```
ERROR: myst-parser 0.17.0 has requirement sphinx<5,>=3.1, but you'll have sphinx 2.4.4 which is incompatible.
ERROR: pydata-sphinx-theme 0.8.1 has requirement sphinx<5,>=3.5.4, but you'll have sphinx 2.4.4 which is incompatible.
ERROR: sphinx-book-theme 0.3.2 has requirement sphinx<5,>=3, but you'll have sphinx 2.4.4 which is incompatible.
```
  which doesn't work, unsurprisingly. By stating our overall minimum sphinx version up-front instead of relying on pip inferring it from our dependencies, we can ensure pip upgrades to an appropriate version of sphinx.