### PR TITLE
CI: Ensure wheel is installed before installing other packages

### DIFF
--- a/.github/workflows/test-release-candidate.yaml
+++ b/.github/workflows/test-release-candidate.yaml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         python -m pip install flake8
         python -m pip install --editable .[test]
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         python -m pip install flake8
         python -m pip install --editable .[test]
 


### PR DESCRIPTION
Sometimes wheel doesn't come pre-installed (seen with Python 3.7 on windows-latest). Installing wheel before other packages speeds up the rest of the installation process as wheels are faster (the alternative, which is used without wheel installed, is `setup.py install`).