### PR TITLE
MNT: Restrict Sphinx<6; v6.1.2 breaking with sphinx-action

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,7 +1,7 @@
 myst-parser
 pypandoc>=1.6.3
 readthedocs-sphinx-search; python_version>='3.6'
-sphinx>=3.5.4
+sphinx>=3.5.4,<6
 sphinx-autobuild
 sphinx_book_theme
 watchdog<1.0.0; python_version<'3.6'


### PR DESCRIPTION
Comparing the docs job from [Dec 26, 2022](https://github.com/scottclowe/python-template-repo/actions/runs/3784988256/jobs/6434696515#step:7:111) (last successful run) to [Jan 9, 2023](https://github.com/scottclowe/python-template-repo/actions/runs/3879745978/jobs/6617221605#step:7:119) (first failure), we can see the change was the Sphinx version moving from 5.3.0 to 6.1.2. Restricting the Sphinx version to be <6 fixes this so we can build the documentation with sphinx-action again.