### PR TITLE
BUG: package_name not replaced in docs/source/conf.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,6 @@ When creating a new repository from this template, these are the steps to follow
 
         sed -i "s/package_name/$PACKAGE_NAME/" setup.py \
             docs/source/conf.py \
-            docs/source/index.rst \
             CHANGELOG.rst \
             .github/workflows/test*.yaml
 
@@ -139,19 +138,15 @@ When creating a new repository from this template, these are the steps to follow
 
     .. highlight:: python
 
-    - In ``setup.py``, `L69 <https://github.com/scottclowe/python-template-repo/blob/master/setup.py#L69>`__::
+    - In ``setup.py``, `L54 <https://github.com/scottclowe/python-template-repo/blob/master/setup.py#L54>`__::
 
-        exec(read('package_name/__meta__.py'), meta)
+        exec(read("package_name/__meta__.py"), meta)
 
-    - In ``docs/conf.py``, `L23 <https://github.com/scottclowe/python-template-repo/blob/master/docs/conf.py#L23>`__::
+    - In ``docs/source/conf.py``, `L27 <https://github.com/scottclowe/python-template-repo/blob/master/docs/source/conf.py#L27>`__::
 
-        from package_name import __meta__ as meta  # noqa: E402
+        from package_name import __meta__ as meta  # noqa: E402 isort:skip
 
-    - In ``docs/index.rst``, `L1 <https://github.com/scottclowe/python-template-repo/blob/master/docs/index.rst#L1>`__::
-
-        package_name documentation
-
-    - In ``.github/workflows/test.yaml``, `L78 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/test.yaml#L78>`__, and ``.github/workflows/test-release-candidate.yaml``, `L90 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/test-release-candidate.yaml#L90>`__::
+    - In ``.github/workflows/test.yaml``, `L64 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/test.yaml#L64>`__, and ``.github/workflows/test-release-candidate.yaml``, `L90 <https://github.com/scottclowe/python-template-repo/blob/master/.github/workflows/test-release-candidate.yaml#L90>`__::
 
         python -m pytest --cov=package_name --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml
 

--- a/README.rst
+++ b/README.rst
@@ -130,8 +130,8 @@ When creating a new repository from this template, these are the steps to follow
     This can be done with the sed command::
 
         sed -i "s/package_name/$PACKAGE_NAME/" setup.py \
-            docs/conf.py \
-            docs/index.rst \
+            docs/source/conf.py \
+            docs/source/index.rst \
             CHANGELOG.rst \
             .github/workflows/test*.yaml
 


### PR DESCRIPTION
Introduced in PR #115 because the conf.py file was moved, but the README wasn't updated to reflect the new location.

We also fix the references to which lines are updated (they have been moved around and/or blackened).
